### PR TITLE
Fix contributors link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ contributor-stats
 
 A project to generate full contributor stats across all ActivityWatch and SuperuserLabs repositories.
 
-Output from this tool is shown on [the ActivityWatch website](https://activitywatch.org/contributors/) for ActivityWatch repos, and not yet anywhere for SuperuserLabs repos (but will someday).
+Output from this tool is shown on [the ActivityWatch website](https://activitywatch.net/contributors/) for ActivityWatch repos, and not yet anywhere for SuperuserLabs repos (but will someday).


### PR DESCRIPTION
The link in the README was using the old activitywatch.org/contributors/ so I fixed it :smile:  