### PR TITLE
chore: add Brayo author merges

### DIFF
--- a/src/contributor_stats/main.py
+++ b/src/contributor_stats/main.py
@@ -67,6 +67,7 @@ def get_authorInfos(data) -> AuthorInfo:
         ("Bill Ang Li", ["Bill-linux"]),
         ("dependabot[bot]", ["dependabot-preview[bot]"]),
         ("Otto-AA", ["A_A"]),
+        ("Brayo", ["brayo"])
     ]
     for name, aliases in author_merges:
         for alias in aliases:


### PR DESCRIPTION
#9 Doesn't exactly merge by email but it fixes my issue. Could do the merge by email later if it's necessary.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f0e541533d0d7fac55a4278d1bcd7c6b56f92729  | 
|--------|--------|

### Summary:
Added a new author merge rule for 'Brayo' in `src/contributor_stats/main.py` to attribute contributions from alias 'brayo' correctly.

**Key points**:
- Added a new author merge rule for 'Brayo' in `src/contributor_stats/main.py`.
- Ensures contributions from alias 'brayo' are attributed to 'Brayo'.
- Modified `get_authorInfos` function to include the new rule.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->