### PR TITLE
feat: render a contributors avatar list from the sync state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__
 *.html
+# Rendered build artifact consumed by the website (see Makefile `render`)
+contributors.yml
 .*cache
 repos/
 *.mp4

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,10 @@ build-aw: clone-aw
 build-sl: clone-sl
 	python3 src/contributor_stats/main.py $(addprefix repos/,$(REPOS_SL))
 
-# Render the GitHub activity table from the committed github-stats-state.json,
-# without calling the GitHub API. The website build (the consumer) uses this to
-# generate the table rather than committing the HTML here.
+# Render the GitHub activity table (github-activity-table.html) and the
+# contributors avatar list (contributors.yml) from the committed
+# github-stats-state.json, without calling the GitHub API. The website build
+# (the consumer) uses this to generate both rather than committing them here.
 render:
 	poetry run python3 src/contributor_stats/github_stats.py --render-only
 

--- a/src/contributor_stats/github_stats.py
+++ b/src/contributor_stats/github_stats.py
@@ -405,6 +405,11 @@ DISPLAY_COLUMNS = [
     "total",
 ]
 
+# Minimum total activity for a user to appear in either rendered artifact, so
+# the table and the contributors list apply the same bar (drive-by/near-zero
+# accounts are excluded from both).
+MIN_ACTIVITY_TOTAL = 10
+
 
 def _aggregate_stats(state: dict) -> pd.DataFrame:
     """Aggregate per-repo stats from saved state into one bot-filtered
@@ -564,8 +569,8 @@ def _aggregate_stats(state: dict) -> pd.DataFrame:
 
 def _render_table(df: pd.DataFrame) -> None:
     """Render the HTML activity table from aggregated stats."""
-    # select only users with total > 10
-    df = df[df["total"] > 10].copy()
+    # drop near-inactive accounts (same bar as the contributors list)
+    df = df[df["total"] > MIN_ACTIVITY_TOTAL].copy()
 
     # linkify GitHub usernames
     df["user"] = df["user"].apply(lambda x: f'<a href="https://github.com/{x}">{x}</a>')
@@ -597,7 +602,10 @@ NUM_CONTRIBUTORS = 64
 def _render_contributors(df: pd.DataFrame) -> None:
     """Render the contributors avatar list consumed by the website's
     _data/contributors.yml (the top contributors by total activity)."""
-    users = df["user"].head(NUM_CONTRIBUTORS).tolist()
+    # same activity bar as the table, so the two artifacts stay consistent even
+    # if the contributor pool ever shrinks below NUM_CONTRIBUTORS
+    eligible = df[df["total"] > MIN_ACTIVITY_TOTAL]
+    users = eligible["user"].head(NUM_CONTRIBUTORS).tolist()
     savepath = Path("contributors.yml")
     with savepath.open("w") as f:
         f.write("\n".join(f"- {user}" for user in users) + "\n")

--- a/src/contributor_stats/github_stats.py
+++ b/src/contributor_stats/github_stats.py
@@ -395,8 +395,24 @@ def _sync(gh: Github, state: dict) -> None:
         _sync_repo(gh, state, repo.full_name)
 
 
-def _render_table(state: dict) -> None:
-    """Render the HTML activity table from saved state (no API calls)."""
+DISPLAY_COLUMNS = [
+    "issues",
+    "comments",
+    "prs",
+    "prs_merged",
+    "pr_comments",
+    "active_days",
+    "total",
+]
+
+
+def _aggregate_stats(state: dict) -> pd.DataFrame:
+    """Aggregate per-repo stats from saved state into one bot-filtered
+    DataFrame sorted by activity, most active first (no API calls).
+
+    Returns columns ``['user'] + DISPLAY_COLUMNS``. Both the HTML activity
+    table and the contributors avatar list are rendered from this.
+    """
     repostats: dict[str, RepoStats] = {}
     for repo_fullname, repo_state in state["repos"].items():
         users = repo_state["users"]
@@ -527,18 +543,9 @@ def _render_table(state: dict) -> None:
         return df
 
     df = df_total(repostats)
-    display_columns = [
-        "issues",
-        "comments",
-        "prs",
-        "prs_merged",
-        "pr_comments",
-        "active_days",
-        "total",
-    ]
 
     pd.set_option("display.max_rows", None, "display.max_columns", None)
-    print(df[display_columns])
+    print(df[DISPLAY_COLUMNS])
     print(df.columns)
 
     # reset index to make user a column (better in HTML)
@@ -547,16 +554,18 @@ def _render_table(state: dict) -> None:
     # filter out bots (named end in "[bot]")
     df = df[~df["user"].str.endswith("[bot]")]
 
-    # sort before saving as HTML
+    # most active first
     df = df.sort_values(
         ["total", "active_days", "user"], ascending=[False, False, True]
     )
 
-    # select subset of columns
-    df = df[["user"] + display_columns]
+    return df[["user"] + DISPLAY_COLUMNS]
 
-    # select only users with total > 1
-    df = df[df["total"] > 10]
+
+def _render_table(df: pd.DataFrame) -> None:
+    """Render the HTML activity table from aggregated stats."""
+    # select only users with total > 10
+    df = df[df["total"] > 10].copy()
 
     # linkify GitHub usernames
     df["user"] = df["user"].apply(lambda x: f'<a href="https://github.com/{x}">{x}</a>')
@@ -577,6 +586,22 @@ def _render_table(state: dict) -> None:
         )
         f.write(html)
     print(f"Written to {savepath}")
+
+
+# Number of top contributors (by total GitHub activity) whose avatars are shown
+# on the website's contributors page. Chosen to roughly preserve the size of the
+# previously hand-maintained _data/contributors.yml.
+NUM_CONTRIBUTORS = 64
+
+
+def _render_contributors(df: pd.DataFrame) -> None:
+    """Render the contributors avatar list consumed by the website's
+    _data/contributors.yml (the top contributors by total activity)."""
+    users = df["user"].head(NUM_CONTRIBUTORS).tolist()
+    savepath = Path("contributors.yml")
+    with savepath.open("w") as f:
+        f.write("\n".join(f"- {user}" for user in users) + "\n")
+    print(f"Written {len(users)} contributors to {savepath}")
     print("Done!")
 
 
@@ -585,7 +610,9 @@ def main(render_only: bool = False) -> None:
     if not render_only:
         gh = _init_gh()
         _sync(gh, state)
-    _render_table(state)
+    df = _aggregate_stats(state)
+    _render_table(df)
+    _render_contributors(df)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Generate the contributors **avatar list** (`contributors.yml`) from `github-stats-state.json`, alongside the existing GitHub activity table.

## Why

The website's contributors page renders a wall of contributor avatars from a **hand-maintained** `_data/contributors.yml`. That list drifts — e.g. it still listed `brayo-pip`, an account since renamed to `0xbrayo` (its avatar 404s). The same sync state that already renders the activity table holds every contributor's activity, so we can emit this list too and let it stay in sync automatically.

## Changes

- Split `_render_table(state)` into:
  - `_aggregate_stats(state) -> DataFrame` — shared, bot-filtered, sorted by total activity
  - `_render_table(df)` — thin HTML renderer (unchanged output)
- Add `_render_contributors(df)` — writes the top `NUM_CONTRIBUTORS` (64) usernames, most active first, to `contributors.yml`. `main()` renders both.
- `.gitignore` `contributors.yml` — it's a build artifact, like `github-activity-table.html`.

`make render` now produces both files; no GitHub API/token needed.

## Consumer

The website build copies `contributors.yml` into `_data/` — see the matching PR on `activitywatch.github.io`.

## Testing

- `make render` (render-only, no token): writes a 64-entry `contributors.yml` (top = ErikBjare, johan-bjareholt, …, with `0xbrayo` correct) and the activity table, structurally unchanged.
- `pytest`: 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)